### PR TITLE
Updated to build with Node 4.2.2

### DIFF
--- a/src/ippool.cc
+++ b/src/ippool.cc
@@ -375,7 +375,7 @@ bool Ippool::StoreIpAddr(Handle<String> str, int version) {
 bool Ippool::StoreIpAddr1(const std::string &str, int version) {
 	Ippool::GenericRange gr;
 	
-	version = Ippool::GetAddr(str, gr, version);
+	version = Ippool::GetAddr1(str, gr, version);
 	
 	if(version == 4) {
 		std::vector<RangeV4>::iterator it;

--- a/src/ippool.cc
+++ b/src/ippool.cc
@@ -279,10 +279,10 @@ std::string Ippool::IpToString(const Ippool::RangeV6 &range) {
 
 int Ippool::GetAddr(Handle<String> str, Ippool::GenericRange &gr, int version) {
 	String::Utf8Value ip(str);
-	return(Ippool::GetAddr(*ip, gr, version));
+	return(Ippool::GetAddr1(*ip, gr, version));
 }
 
-int Ippool::GetAddr(const std::string &str, Ippool::GenericRange &gr, int version) {
+int Ippool::GetAddr1(const std::string &str, Ippool::GenericRange &gr, int version) {
 	char address_buffer[sizeof(struct in6_addr)];
 	std::string sub;
 	size_t pos;
@@ -369,10 +369,10 @@ int Ippool::GetAddr(const std::string &str, Ippool::GenericRange &gr, int versio
 
 bool Ippool::StoreIpAddr(Handle<String> str, int version) {
 	String::Utf8Value ip(str);
-	return(this->StoreIpAddr(*ip, version));
+	return(this->StoreIpAddr1(*ip, version));
 }
 
-bool Ippool::StoreIpAddr(const std::string &str, int version) {
+bool Ippool::StoreIpAddr1(const std::string &str, int version) {
 	Ippool::GenericRange gr;
 	
 	version = Ippool::GetAddr(str, gr, version);

--- a/src/ippool.hh
+++ b/src/ippool.hh
@@ -55,9 +55,9 @@ class Ippool : public node::ObjectWrap {
 		static std::string IpToString(const RangeV4 &range);
 		static std::string IpToString(const RangeV6 &range);
 		static int GetAddr(v8::Handle<v8::String> str, GenericRange &gr, int version = 0);
-		static int GetAddr(const std::string &str, GenericRange &gr, int version = 0);
+		static int GetAddr1(const std::string &str, GenericRange &gr, int version = 0);
 		bool StoreIpAddr(v8::Handle<v8::String> str, int version = 0);
-		bool StoreIpAddr(const std::string &str, int version = 0);
+		bool StoreIpAddr1(const std::string &str, int version = 0);
 		static int ParseMask(const std::string &maskStr, int version);
 		bool searchv4(const RangeV4 &range);
 		bool searchv6(const RangeV6 &range);


### PR DESCRIPTION
Building on Node v4.2.2 on Ubuntu 14.04, repeated errors of the form

<code>
make: Entering directory `/var/local/textibility.api/node_modules/node-ipaddr/build'
  CXX(target) Release/obj.target/ippool/src/module.o
  CXX(target) Release/obj.target/ippool/src/ippool.o
../src/ippool.cc: In static member function ‘static int Ippool::GetAddr(v8::Handlev8::String, Ippool::GenericRange&, int)’:
../src/ippool.cc:282:41: error: call of overloaded ‘GetAddr(char_, Ippool::GenericRange&, int&)’ is ambiguous
  return(Ippool::GetAddr(_ip, gr, version));
                                         ^
../src/ippool.cc:282:41: note: candidates are:
../src/ippool.cc:280:5: note: static int Ippool::GetAddr(v8::Handlev8::String, Ippool::GenericRange&, int)
 int Ippool::GetAddr(Handle<String> str, Ippool::GenericRange &gr, int version) {
     ^
In file included from ../src/module.hh:37:0,
                 from ../src/ippool.cc:22:
../src/ippool.hh:58:14: note: static int Ippool::GetAddr(const string&, Ippool::GenericRange&, int)
   static int GetAddr(const std::string &str, GenericRange &gr, int version = 0);
              ^
../src/ippool.cc: In member function ‘bool Ippool::StoreIpAddr(v8::Handlev8::String, int)’:
../src/ippool.cc:372:39: error: call of overloaded ‘StoreIpAddr(char_, int&)’ is ambiguous
  return(this->StoreIpAddr(_ip, version));
                                       ^
../src/ippool.cc:372:39: note: candidates are:
../src/ippool.cc:370:6: note: bool Ippool::StoreIpAddr(v8::Handlev8::String, int)
 bool Ippool::StoreIpAddr(Handle<String> str, int version) {
      ^
In file included from ../src/module.hh:37:0,
                 from ../src/ippool.cc:22:
../src/ippool.hh:60:8: note: bool Ippool::StoreIpAddr(const string&, int)
   bool StoreIpAddr(const std::string &str, int version = 0);
        ^
../src/ippool.cc: In static member function ‘static int Ippool::GetAddr(v8::Handlev8::String, Ippool::GenericRange&, int)’:
../src/ippool.cc:283:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
../src/ippool.cc: In member function ‘bool Ippool::StoreIpAddr(v8::Handlev8::String, int)’:
../src/ippool.cc:373:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
make: **\* [Release/obj.target/ippool/src/ippool.o] Error 1
</code>

are happening. I did a trivial rename of a number of functions to work around this, and now it build correctly.
